### PR TITLE
Fix typo

### DIFF
--- a/zh-Hant.md
+++ b/zh-Hant.md
@@ -120,7 +120,7 @@
 [顯示表](tables/paradigms.yaml)
 
 
-並發計算
+併發計算
 --------
 
 [顯示表](tables/concurrency.yaml)


### PR DESCRIPTION
Fix typo in `zh-Hant.md`: 並發計算 > 併發計算