### PR TITLE
Fix explanation for ‘function’

### DIFF
--- a/tables/programming.yaml
+++ b/tables/programming.yaml
@@ -231,9 +231,9 @@
     function:
     - term: function
   ja:
-    關數:
-    - { term: 関, correspond: relative, read: かん }
-    - { term: 数, correspond: number,   read: すう, space: no }
+    函數:
+    - { term: 関, correspond: box,    read: かん }
+    - { term: 数, correspond: number, read: すう, space: no }
   ko:
     函數:
     - { term: 函, correspond: box,    read: 함 }
@@ -252,7 +252,7 @@
     - { term: 數, correspond: number, read: ㄕㄨˋ,  space: no }
     函式:
     - { term: 函, correspond: box,    read: ㄏㄢˊ }
-    - { term: 式, correspond: number, read: ㄕˋ,    space: no }
+    - { term: 式, correspond: style,  read: ㄕˋ,    space: no }
 
 # Return value
 - en:


### PR DESCRIPTION
1\. `ja` 関数 cognates with `zh-HK` 函數.

[Wiktionary](https://ja.wiktionary.org/wiki/%E5%87%BD%E6%95%B0): 日本語としての関数はもともと「函数」と書く。これは英語 "function" の中国における訳語である函数 (hánshù) をそのまま輸入したものであるが、「函」が漢字制限による常用漢字に含まれなかったため1950年代以降、同音の「関」へと書き換えがすすめられた。

Besides, ‘function’ appears in another part of this project, and that part is correct:
https://github.com/dahlia/cjk-compsci-terms/blob/1fcbf1daad0912b78653148a496483dd45e8c412/tables/paradigms.yaml#L146-L155

2\. 式 in `zh-TW` means ‘style’, but is mistakenly written as ‘number’.

承上而誤